### PR TITLE
HTW weather data for pvlib simulation #64

### DIFF
--- a/pv3_main.py
+++ b/pv3_main.py
@@ -56,12 +56,15 @@ if __name__ == "__main__":
         """)
     df_htw = pd.read_sql_query(sql, con)
     df_htw = df_htw.set_index('timestamp')
-    htw_weatherdata_names = {"G_hor_Si": "ghi",
+    htw_weatherdata_names = {"g_hor_si": "ghi",
                              'v_wind': "wind_speed",
                              't_luft': "temp_air",
                              }
     df_htw = df_htw.rename(columns=htw_weatherdata_names)
     df_dhi = calculate_diffuse_irradiation(df_htw, "ghi", HTW_LAT, HTW_LON)
+    df_htw = df_htw.merge(df_dhi[['dhi', 'dni']], left_index=True, right_index=True)
+    df_htw_select = df_htw.loc[:, ["ghi", "dhi", 'dni', "wind_speed", "temp_air"]]
+    df_htw_pvlib = df_htw_select.resample('H').mean()
 
     # read open_FRED weatherdata from sonnja_db
     sql = text("""
@@ -116,7 +119,6 @@ if __name__ == "__main__":
 
     # weather data
     df_fred_pvlib = df_fred.resample('H').mean()
-    df_htw_pvlib = df_fred.resample('H').mean()
 
     # model chain
     mc1 = setup_modelchain(wr1, htw_location)

--- a/pv3_main.py
+++ b/pv3_main.py
@@ -126,6 +126,11 @@ if __name__ == "__main__":
     mc3 = setup_modelchain(wr3, htw_location)
     mc4 = setup_modelchain(wr4, htw_location)
     mc5 = setup_modelchain(wr5, htw_location)
+    mc1_htw = setup_modelchain(wr1, htw_location)
+    mc2_htw = setup_modelchain(wr2, htw_location)
+    mc3_htw = setup_modelchain(wr3, htw_location)
+    mc4_htw = setup_modelchain(wr4, htw_location)
+    mc5_htw = setup_modelchain(wr5, htw_location)
 
     # run modelchain
     run_modelchain(mc1, df_fred_pvlib)
@@ -133,6 +138,11 @@ if __name__ == "__main__":
     run_modelchain(mc3, df_fred_pvlib)
     run_modelchain(mc4, df_fred_pvlib)
     run_modelchain(mc5, df_fred_pvlib)
+    run_modelchain(mc1_htw, df_htw_pvlib)
+    run_modelchain(mc2_htw, df_htw_pvlib)
+    run_modelchain(mc3_htw, df_htw_pvlib)
+    run_modelchain(mc4_htw, df_htw_pvlib)
+    run_modelchain(mc5_htw, df_htw_pvlib)
 
     # export results
 

--- a/pv3_main.py
+++ b/pv3_main.py
@@ -151,6 +151,7 @@ if __name__ == "__main__":
     # print(mc3.ac)
 
     # yield
+    log.info(f'OpenFRED Weather Data')
     res_wr1_ac = mc1.ac
     res_wr1_ac_sum = res_wr1_ac.sum()/1000
     log.info(f'Annual yield WR1: {res_wr1_ac_sum}')
@@ -164,6 +165,26 @@ if __name__ == "__main__":
     res_wr4_ac_sum = res_wr4_ac.sum() / 1000
     log.info(f'Annual yield WR4: {res_wr4_ac_sum}')
     res_wr5_ac = mc5.ac
+    res_wr5_ac_sum = res_wr5_ac.sum() / 1000
+    log.info(f'Annual yield WR5: {res_wr5_ac_sum}')
+
+    res_sum = res_wr1_ac_sum + res_wr2_ac_sum + res_wr3_ac_sum + res_wr4_ac_sum + res_wr5_ac_sum
+    log.info(f'Annual yield SonnJA: {res_sum}')
+
+    log.info(f'HTW Weather Data')
+    res_wr1_ac = mc1_htw.ac
+    res_wr1_ac_sum = res_wr1_ac.sum()/1000
+    log.info(f'Annual yield WR1: {res_wr1_ac_sum}')
+    res_wr2_ac = mc2_htw.ac
+    res_wr2_ac_sum = res_wr2_ac.sum() / 1000
+    log.info(f'Annual yield WR2: {res_wr2_ac_sum}')
+    res_wr3_ac = mc3_htw.ac
+    res_wr3_ac_sum = res_wr3_ac.sum() / 1000
+    log.info(f'Annual yield WR3: {res_wr3_ac_sum}')
+    res_wr4_ac = mc4_htw.ac
+    res_wr4_ac_sum = res_wr4_ac.sum() / 1000
+    log.info(f'Annual yield WR4: {res_wr4_ac_sum}')
+    res_wr5_ac = mc5_htw.ac
     res_wr5_ac_sum = res_wr5_ac.sum() / 1000
     log.info(f'Annual yield WR5: {res_wr5_ac_sum}')
 


### PR DESCRIPTION
Add code to use HTW weather data in the simulation. Results are too high, the problem might lie with `pvlib.irradiance.erbs` or time series resampling.
Using `g_hor_cmp6` instead of `g_hor_si` did not fix the problem